### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/core/src/library/tools/R/bibstyle.R
+++ b/core/src/library/tools/R/bibstyle.R
@@ -64,7 +64,7 @@ makeJSS <- function()
 	fmtBook <- emphclean
 	fmtBtitle <- emphclean
 	fmtChapter <- labelclean(prefix="chapter ")
-	fmtDOI <- label(prefix="\\url{http://dx.doi.org/", suffix="}")
+	fmtDOI <- label(prefix="\\url{https://doi.org/", suffix="}")
 	fmtEdition <- labelclean(suffix=" edition")
 	fmtEprint <- plain
 	fmtHowpublished <- plainclean


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). If I understood your code correctly, it generated links / URLs from the DOIs, correct? If yes, please consider integrating this change, see diff.

Cheers :-)